### PR TITLE
Perform the ending of TGenerationThread.Execute in the main thread

### DIFF
--- a/Mazer.pas
+++ b/Mazer.pas
@@ -69,6 +69,7 @@ var
   loadscreen_img: TCastleImageControl;
   Loadscreen_label: TCastleLabel;
   GenerationThread:TGenerationThread; //thread for generating the dungeon in background
+  GenerationThreadFinishExecute: boolean;
 
 {==========================================================================}
 {============================ PROCEDURES ==================================}
@@ -314,12 +315,7 @@ begin
  writeln('Generating Map...');
  GenerateMap;  //generate the map;
 
- //final initializations
- window.Controls.Remove(loadscreen_img);
- window.Controls.Remove(loadscreen_label);
- Window.scenemanager.camera:=player.camera;
-
- GameMode:=GameMode_game;
+ GenerationThreadFinishExecute := true;
 end;
 
 {---------------}
@@ -389,6 +385,18 @@ begin
 
   if gamemode=gamemode_loadscreen then window.DoRender;
   if gamemode=gamemode_game then application.TimerMilisec:=1000; //reset timer back to 1s in-game, it was 60fps for loading screen
+
+  if GenerationThreadFinishExecute then
+  begin
+    //final initializations
+    window.Controls.Remove(loadscreen_img);
+    window.Controls.Remove(loadscreen_label);
+    Window.scenemanager.camera:=player.camera;
+
+    GameMode:=GameMode_game;
+
+    GenerationThreadFinishExecute := false;
+  end;
 end;
 
 {==========================================================================}


### PR DESCRIPTION
Fix a crash on Linux inside the OpenGL `glDeleteTexture` call, happening indirectly from the `Window.Controls.Remove` call in `TGenerationThread.Execute`.

See the details in https://github.com/eugeneloza/Mazer/commit/4a17285db056dcd072e0eef4389e642403769fa9 commit log.

---

**Notes about CGE and threads**:

We should mark in the docs explicitly which CGE APIs are Ok to be used from multiple threads, and under which circumstances. In many cases it's Ok, but in general we don't guarantee it works --- not everything in CGE is secured for multiple threads, and some of our underlying libraries (like OpenGL) are also not OK with this.

So in general, you should operate on Castle Game Engine and OpenGL objects only from the main thread. Although many Castle Game Engine constructs work even when accessed from other threads, as long as you don't access them simultaneously, there's no guarantee that things always work Ok (we do use a few global variables e.g. for global cache).

In this case, OpenGL refuses to work. We could work around it by making the context current in another thread (see http://www.equalizergraphics.com/documentation/parallelOpenGLFAQ.html ), but I'm not sure how to expose this API nicely. Besides, benefits are small (google "opengl multiple threads" confirms it --- everything it processed by a single GPU anyway). So it may be easier to just require to do everything OpenGL-related from the single thread.

This means that, while you can always offload some "general" (not related to CGE or LCL) work to another thread, and it also works for some subset of engine commands, and e.g. file reading works from any thread (because OS allows it)... but it's not guaranteed to work for all operations in CGE. Lazarus LCL also in general works only from the main thread, same as GTK, WinAPI etc. underneath.

Note that OpenAL (sound engine) is more relaxed in this regard than OpenGL. OpenGL context is associated with a thread, but OpenAL context is by default associated with a whole process, and accepts commands from any thread (see e.g. http://stackoverflow.com/questions/6255734/playing-openal-sounds-from-background-thread ).
